### PR TITLE
yarn -> npm

### DIFF
--- a/docker-website-deployment/Dockerfile
+++ b/docker-website-deployment/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine
 COPY config /root/.aws/
 
 RUN apk update && apk upgrade
-RUN apk --no-cache add make bash curl openssh git unzip jq python3 outils-cksum yarn npm && \
+RUN apk --no-cache add make bash curl openssh git unzip jq python3 outils-cksum npm && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade pip setuptools && \

--- a/docker-website-deployment/README.md
+++ b/docker-website-deployment/README.md
@@ -1,7 +1,9 @@
-### Website deployment using yarn
+### Website deployment
+
+> Deployment is using npm by default
 
 To pull this image:  
-`docker pull tendermintdev/docker-website-deployment-yarn`  
+`docker pull tendermintdev/docker-website-deployment`
 
 Image is used to deploy new versions of S3 hosted websites.
 


### PR DESCRIPTION
Removed `yarn` in `docker-website-deployment/Dockerfile` and `docker-website-deployment/README.md`

I made the changes because we're moving away from yarn. Cleaned up the Dockerfile and image to avoid any confusion in the future.