### PR TITLE
add clang to format proto code

### DIFF
--- a/docker-build-proto/Dockerfile
+++ b/docker-build-proto/Dockerfile
@@ -33,10 +33,8 @@ ENV \
   ALPINE_PROTOBUF_VERSION_SUFFIX=r0
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
-  apk add --update --no-cache grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
+  apk add --update --no-cache grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} clang && \
   rm -rf /var/cache/apk/*
-
-RUN apk add --no-cache clang
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include

--- a/docker-build-proto/Dockerfile
+++ b/docker-build-proto/Dockerfile
@@ -27,14 +27,16 @@ FROM alpine:edge
 WORKDIR /work
 
 ENV \
-  GRPC_VERSION=1.31.1 \
-  PROTOBUF_VERSION=3.12.3 \
+  GRPC_VERSION=1.32.0 \
+  PROTOBUF_VERSION=3.13.0 \
   ALPINE_GRPC_VERSION_SUFFIX=r0 \
   ALPINE_PROTOBUF_VERSION_SUFFIX=r0
 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
   apk add --update --no-cache grpc=${GRPC_VERSION}-${ALPINE_GRPC_VERSION_SUFFIX} protobuf=${PROTOBUF_VERSION}-${ALPINE_PROTOBUF_VERSION_SUFFIX} && \
   rm -rf /var/cache/apk/*
+
+RUN apk add --no-cache clang
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/include /usr/include


### PR DESCRIPTION
This PR adds clang to the proto docker image and updates proto deps. This is done so that users can run `make proto-format` within tendermint in order to avoid downloading clang-format