### PR TITLE
rbuilder: move build.sh into /scripts

### DIFF
--- a/rbuilder/Dockerfile
+++ b/rbuilder/Dockerfile
@@ -28,4 +28,4 @@ WORKDIR /sources
 VOLUME [ "/sources" ]
 
 # Run the application's build.sh.
-ENTRYPOINT [ "/sources/build.sh" ]
+ENTRYPOINT [ "/sources/scripts/build.sh" ]

--- a/rbuilder/README.md
+++ b/rbuilder/README.md
@@ -1,12 +1,12 @@
 # Reproducible Build System
 
 This image is meant to provide a minimal deterministic
-buildsystem for Cosmos SDK applications.
+build system for Tendermint applications.
 
 # Requirements And Usage
 
 The client application's repository must include an
-`build.sh` executable file in the root folder meant to drive the build
+`build.sh` executable file in the `/scripts` folder meant to drive the build
 process. The following environment variables are passed through
 and made available to the `build.sh` script:
 


### PR DESCRIPTION
I think this is the reciprocal change needed for https://github.com/tendermint/tendermint/pull/5627. 