### PR TITLE
change scripts installation path

### DIFF
--- a/rbuilder/Dockerfile
+++ b/rbuilder/Dockerfile
@@ -13,7 +13,7 @@ RUN useradd -ms /bin/bash -U builder
 ARG APP
 ARG DEBUG
 ARG TARGET_PLATFORMS
-ENV APP ${APP:-tendermint}
+ENV APP ${APP:-app}
 ENV DEBUG ${DEBUG}
 ENV VERSION unknown
 ENV COMMIT unknown

--- a/rbuilder/Dockerfile
+++ b/rbuilder/Dockerfile
@@ -3,17 +3,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get --no-install-recommends -y install \
     pciutils build-essential git wget \
     lsb-release dpkg-dev curl bsdmainutils fakeroot
-RUN mkdir -p /usr/local/share/cosmos-sdk/
+RUN mkdir -p /usr/local/share/tendermint/
 
 # Deploy the shell functions library.
-COPY buildlib.sh /usr/local/share/cosmos-sdk/
+COPY buildlib.sh /usr/local/share/tendermint/
 
 # Create the 'builder' user.
 RUN useradd -ms /bin/bash -U builder
 ARG APP
 ARG DEBUG
 ARG TARGET_PLATFORMS
-ENV APP ${APP:-cosmos-sdk}
+ENV APP ${APP:-tendermint}
 ENV DEBUG ${DEBUG}
 ENV VERSION unknown
 ENV COMMIT unknown

--- a/rbuilder/Dockerfile
+++ b/rbuilder/Dockerfile
@@ -19,6 +19,7 @@ ENV VERSION unknown
 ENV COMMIT unknown
 ENV LEDGER_ENABLE true
 ENV TARGET_PLATFORMS ${TARGET_PLATFORMS:-linux/amd64}
+ENV BUILD_SCRIPT ${BUILD_SCRIPT:-/sources/.build.sh}
 
 # Drop root privileges.
 USER builder:builder
@@ -28,4 +29,4 @@ WORKDIR /sources
 VOLUME [ "/sources" ]
 
 # Run the application's build.sh.
-ENTRYPOINT [ "/sources/build.sh" ]
+ENTRYPOINT [ "/bin/bash", "-c", "${BUILD_SCRIPT}" ]

--- a/rbuilder/README.md
+++ b/rbuilder/README.md
@@ -6,9 +6,9 @@ buildsystem for Cosmos SDK applications.
 # Requirements And Usage
 
 The client application's repository must include an
-`build.sh` executable file in the root folder meant to drive the build
+`.build.sh` executable file in the root folder meant to drive the build
 process. The following environment variables are passed through
-and made available to the `build.sh` script:
+and made available to the `.build.sh` script:
 
 * `APP` - the application's name.
 * `VERSION` - the application's version.
@@ -16,8 +16,9 @@ and made available to the `build.sh` script:
 * `TARGET_PLATFORMS` - whitespace-separated list of operating system/architecture pairs. `linux/amd64`, `linux/arm64`, `darwin/amd64`, and `windows/amd64` are supported. Default: `linux/amd64`.
 * `LEDGER_ENABLED` - whether Ledger is enabled (default: `true`).
 * `DEBUG` - run build with debug output. Default: empty (disabled).
+* `BUILD_SCRIPT` - path to the build script. Default: `.build.sh`
 
-The build's outputs are produced in the top-level `artifacts` directory. An example of `build.sh` follows:
+The build's outputs are produced in the top-level `artifacts` directory. An example of `.build.sh` follows:
 
 ```bash
 #!/bin/bash

--- a/rbuilder/README.md
+++ b/rbuilder/README.md
@@ -33,7 +33,7 @@ set -ue
 # - DEBUG
 
 # Source builder's functions library
-. /usr/local/share/cosmos-sdk/buildlib.sh
+. /usr/local/share/tendermint/buildlib.sh
 
 # These variables are now available
 # - BASEDIR


### PR DESCRIPTION
Install platform agnostic build library in /usr/local/share/tendermint/.

Set default APP to tendermint.

Source build script from $BUILD_SCRIPT.